### PR TITLE
Fixed HeightColorMap landclasses and VolonoiCraters

### DIFF
--- a/Source/PFUtilityAddon.csproj
+++ b/Source/PFUtilityAddon.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
+    <OutputPath>Z:\Kerbal Space Program\GameData\KittopiaSpace\Plugins\</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Source/Planet_GUI.cs
+++ b/Source/Planet_GUI.cs
@@ -10,6 +10,7 @@ using KSP.IO;
 
 namespace PFUtilityAddon
 {
+
 	public class RingSaveStorageHelper
 	{
 		public RingSaveStorageHelper(float ITilt, double IOuterRadius, double IInnerRadius, Color IColour, GameObject IgObj, bool IUnlit, bool ILockRot )
@@ -147,7 +148,7 @@ namespace PFUtilityAddon
 				try
 				{
 					//Load globals...
-					LoadData( psB.celestialBody.name, "GameData/KittopiaSpace/SaveLoad/"+psB.celestialBody.name+".cfg" );
+					LoadData( psB.celestialBody.name, "GameData/KittopiaSpace/SaveLoad/" );
 				}
 				catch( Exception e )
 				{ 
@@ -588,7 +589,7 @@ namespace PFUtilityAddon
 			{
 				if( TemplateName != null )
 				{
-					LoadData( TemplateName, "GameData/KittopiaSpace/SaveLoad/"+TemplateName+".cfg" );
+					LoadData( TemplateName, "GameData/KittopiaSpace/SaveLoad/" );
 				}
 			}
 			
@@ -2227,6 +2228,7 @@ namespace PFUtilityAddon
 			foreach( PQSMod pqs in Utils.FindLocal(TemplateName).GetComponentsInChildren(typeof( PQSMod )) )
 			{
 				ConfigNode savePQS = PQSRoot.AddNode( ""+pqs.GetType() );
+                savePQS.AddValue("object name", pqs.gameObject.name);
 				foreach( FieldInfo key in pqs.GetType().GetFields() )
 				{
 					try{
@@ -2267,6 +2269,31 @@ namespace PFUtilityAddon
 								}
 							}
 						}
+                        if (key.FieldType == typeof(PQSMod_HeightColorMap.LandClass[]))
+                        {
+                            ConfigNode landclasses_root = savePQS.AddNode("HMLandclass[]");
+                            foreach (PQSMod_HeightColorMap.LandClass lc in (PQSMod_HeightColorMap.LandClass[])key.GetValue(obj))
+                            {
+                                ConfigNode landclass = landclasses_root.AddNode("Landclass");
+                                foreach (FieldInfo key2 in lc.GetType().GetFields())
+                                {
+                                    try
+                                    {
+                                        System.Object obj2 = (System.Object)lc;
+                                        if (key2.GetValue(obj2).GetType() == typeof(string)
+                                            || key2.GetValue(obj2).GetType() == typeof(double)
+                                            || key2.GetValue(obj2).GetType() == typeof(int)
+                                            || key2.GetValue(obj2).GetType() == typeof(float)
+                                            || key2.GetValue(obj2).GetType() == typeof(bool)
+                                            || key2.GetValue(obj2).GetType() == typeof(Color))
+                                        {
+                                            landclass.AddValue(key2.Name, key2.GetValue(obj2));
+                                        }
+                                    }
+                                    catch { }
+                                }
+                            }
+                        }
 						if( key.FieldType == typeof( PQSMod_VertexPlanet.LandClass[] ) )
 						{
 							ConfigNode landclasses_root = savePQS.AddNode( "VPLandclass[]" );
@@ -2299,13 +2326,14 @@ namespace PFUtilityAddon
 		
 		//Data Loader
 		public void LoadData( string PlanetName, string path )
-		{	
-			if( !Utils.FileExists(path) )
+		{
+            string file = System.IO.Directory.GetFiles(path, PlanetName + ".cfg", System.IO.SearchOption.AllDirectories).FirstOrDefault();
+            if (file == null)
 			{
 				print("PlanetUI: No data loaded for " +PlanetName+ "\n" );
 				return;
 			}
-			cfgNodes = ConfigNode.Load( path );
+			cfgNodes = ConfigNode.Load( file );
 			if( cfgNodes == null )
 			{
 				print("PlanetUI: No data loaded for " +PlanetName+ "\n" );
@@ -2741,7 +2769,6 @@ namespace PFUtilityAddon
 							print("Cant find PQSMod type:" + componentTypeStr + "\n");
 							continue;
 						}
-
 						print( node.name + "\n" );
 						if( localPlanet.GetComponentInChildren(componentType) == null )
 						{
@@ -2759,7 +2786,7 @@ namespace PFUtilityAddon
 						System.Object obj = component;
 						foreach( FieldInfo key in obj.GetType().GetFields() )
 						{
-							//print ( "PlanetUI: Debug: " +PlanetName + " Component: " + key.Name +"\n" );
+							//Debug.Log ( "PlanetUI: Debug: " +PlanetName + " Component: " + key.Name + " Type: " + key.FieldType );
 							try
 							{
 								if( node.HasValue( key.Name ) )
@@ -2768,10 +2795,10 @@ namespace PFUtilityAddon
 									{
 										//key.SetValue( cbobj, ConfigNode.ParseColor( val ) );
 										//print ( "PQS not compatible at this point." );
-										//continue;
-										string FixName = node.GetValue( key.Name );
-										FixName = FixName.Replace(" (PQS)", "");
-										key.SetValue( obj, Utils.FindPQS( FixName ) );
+										continue;
+										//string FixName = node.GetValue( key.Name );
+										//FixName = FixName.Replace(" (PQS)", "");
+										//key.SetValue( obj, Utils.FindPQS( FixName ) );
 									}
 									if( key.FieldType == typeof( PQSLandControl.LandClass[] ) )
 									{
@@ -2790,12 +2817,12 @@ namespace PFUtilityAddon
 										LoadVPLandControl( node.GetNode("VPLandclass[]") , obj , key );
 									}
 								
-									//print( "PlanetUI: Attempting: " + key.Name + " of type " + key.FieldType + "\n" );
+									//Debug.Log( "PlanetUI: Attempting: " + key.Name + " of type " + key.FieldType + "\n" );
 									string val = node.GetValue( key.Name );
 									System.Object castedval = val;
 									Type t = key.FieldType;
 								
-									//print( "PlanetUI: " + component + " " + key.Name + " = ("+t+") " + castedval + "\n" );
+									//Debug.Log( "PlanetUI: " + component + " " + key.Name + " = ("+t+") " + castedval + "\n" );
 								
 									if ( t == typeof(UnityEngine.Vector3) )
 									{
@@ -2835,6 +2862,12 @@ namespace PFUtilityAddon
 										key.SetValue( obj, Convert.ChangeType( castedval, t ) );
 									}
 								}
+                                if (key.Name == "landClasses" && node.HasNode("HMLandclass[]"))
+                                {
+                                    //Debug.Log("Found landclass");
+                                    ParseColorMapLandclass(node.GetNode("HMLandclass[]"),localPlanet);
+                                    
+                                }
 							}
 							catch( Exception e )
 							{
@@ -2842,6 +2875,7 @@ namespace PFUtilityAddon
 								continue;
 							}
 						}
+                        
 					
 						if( node.HasValue("Parent") )
 						{
@@ -2897,6 +2931,33 @@ namespace PFUtilityAddon
 				print("PlanetUI: No data loaded for " +PlanetName+ "\n" );
 			}
 		}
+
+
+        void ParseColorMapLandclass(ConfigNode pqsNode, GameObject root)
+        {
+            Color color = Color.white;
+
+            PQSMod_HeightColorMap heightColorMap = root.GetComponentsInChildren<PQSMod_HeightColorMap>()[0];
+            List<PQSMod_HeightColorMap.LandClass> landClasses = new List<PQSMod_HeightColorMap.LandClass>();
+
+            PQSMod_HeightColorMap.LandClass landClass;
+
+            foreach (ConfigNode node in pqsNode.nodes)
+            {
+                
+                    var val = node.GetValue("color");
+                    val = val.Replace("RGBA(", "");
+                    val = val.Replace(")", "");
+                    color = ConfigNode.ParseColor(val);
+
+                    landClass = new PQSMod_HeightColorMap.LandClass(node.GetValue("name"), double.Parse(node.GetValue("altStart")), double.Parse(node.GetValue("altEnd")),color, Color.white, double.NaN);
+                    landClass.lerpToNext = bool.Parse(node.GetValue("lerpToNext"));
+                    landClasses.Add(landClass);
+            }
+            heightColorMap.landClasses = landClasses.ToArray();
+            heightColorMap.lcCount = heightColorMap.landClasses.Length;
+            heightColorMap.requirements = PQS.ModiferRequirements.MeshColorChannel;
+        }
 		void LoadLandControl( ConfigNode pqsNode, System.Object obj, FieldInfo key )
 		{
 			//int count = pqsNode.CountNodes;

--- a/Source/Planet_GUI.cs
+++ b/Source/Planet_GUI.cs
@@ -2228,7 +2228,6 @@ namespace PFUtilityAddon
 			foreach( PQSMod pqs in Utils.FindLocal(TemplateName).GetComponentsInChildren(typeof( PQSMod )) )
 			{
 				ConfigNode savePQS = PQSRoot.AddNode( ""+pqs.GetType() );
-                savePQS.AddValue("object name", pqs.gameObject.name);
 				foreach( FieldInfo key in pqs.GetType().GetFields() )
 				{
 					try{

--- a/Source/PlanetaryUtilClass.cs
+++ b/Source/PlanetaryUtilClass.cs
@@ -119,9 +119,22 @@ namespace PFUtilityAddon
 		{
 			var newgob = new GameObject();
             var newComponent = (PQSMod)newgob.AddComponent(ofType);
-			newgob.name = (""+ofType);
-			newgob.transform.parent = mainSphere.gameObject.transform;
-            newComponent.sphere = mainSphere;
+
+            if (ofType.Name == "PQSMod_VoronoiCraters")
+            {
+                var mun = Utils.FindCB("Mun");
+                var craters = mun.GetComponentsInChildren<PQSMod_VoronoiCraters>()[0];
+                
+                PQSMod_VoronoiCraters nc = newComponent.GetComponentsInChildren<PQSMod_VoronoiCraters>()[0];
+                nc.craterColourRamp = craters.craterColourRamp;
+                nc.craterCurve = craters.craterCurve;
+                nc.jitterCurve = craters.jitterCurve;
+            }
+
+                newgob.name = ("Craters");
+                newgob.transform.parent = mainSphere.gameObject.transform;
+                newComponent.sphere = mainSphere;
+            
 			
 			return newComponent;
 		}

--- a/Source/PlanetaryUtilClass.cs
+++ b/Source/PlanetaryUtilClass.cs
@@ -130,12 +130,10 @@ namespace PFUtilityAddon
                 nc.craterCurve = craters.craterCurve;
                 nc.jitterCurve = craters.jitterCurve;
             }
-
-                newgob.name = ("Craters");
+                newgob.name = (""+ofType);
                 newgob.transform.parent = mainSphere.gameObject.transform;
                 newComponent.sphere = mainSphere;
             
-			
 			return newComponent;
 		}
 		


### PR DESCRIPTION
Made it so landclasses from HeightColorMaps are saved and read in from config file.
Added quick fix to AddPQSMod() so that it creates VolonoiCraters by copying the settings from the Mun.  This is done so that the craterCurve, jitterCurve, and craterColorRamp are not null.

Colors in the new landclasses can't yet be set from the gui, has to be done through config. Gui will come later, thinking of refactoring the entire thing as it currently gives me a headache reading it
